### PR TITLE
Redirect fra labs til dev ekstern

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - enable-dev-ekstern-uten-innlogging
+      - redirect-fra-labs-til-dev-ekstern
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}:${{ github.sha }}
@@ -71,13 +71,31 @@ jobs:
           RESOURCE: .nais/nais.yaml
           VARS: .nais/${{ matrix.cluster }}.yaml
 
-  deploy-main-to-dev-ekstern:
+  deploy-feature-branch-to-dev:
+    strategy:
+      matrix:
+        cluster: [ dev ]
+    name: Deploy app to dev (feature branch)
+    needs: build
+    if: github.ref == 'refs/heads/redirect-fra-labs-til-dev-ekstern'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy to dev-ekstern
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: ${{ matrix.cluster }}-gcp
+          RESOURCE: .nais/nais.yaml
+          VARS: .nais/${{ matrix.cluster }}.yaml
+
+  deploy-main-or-feature-branch-to-dev-ekstern:
     strategy:
       matrix:
         cluster: [ dev ]
     name: Deploy app to dev-ekstern
     needs: build
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/enable-dev-ekstern-uten-innlogging'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/redirect-fra-labs-til-dev-ekstern'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -89,13 +107,13 @@ jobs:
           RESOURCE: .nais/nais.yaml
           VARS: .nais/dev-ekstern.yaml
 
-  deploy-main-to-labs:
+  deploy-main-or-feature-branch-to-labs:
     strategy:
       matrix:
         cluster: [ labs ]
     name: Deploy app to labs
     needs: build
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/enable-dev-ekstern-uten-innlogging'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/redirect-fra-labs-til-dev-ekstern'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -32,6 +32,13 @@ spec:
     outbound:
       rules:
         - application: forebyggingsplan
+      external:
+        - host: api.sanity.io
+        - host: 2u7e6oll.api.sanity.io
+        - host: apicdn.sanity.io
+        - host: 2u7e6oll.apicdn.sanity.io
+        - host: cdn.sanity.io
+
   env:
     - name: FOREBYGGINGSPLAN_API_BASEURL
       value: {{ forebyggingsplanBaseurl }}

--- a/src/lib/miljø.ts
+++ b/src/lib/miljø.ts
@@ -13,6 +13,9 @@ export const isMock = () =>
 export const isDev = () =>
     (process.env.NAIS_CLUSTER_NAME as Miljø) === "dev-gcp";
 
+export const isLabs = () =>
+    (process.env.NAIS_CLUSTER_NAME as Miljø) === "labs-gcp";
+
 export const isLocalhost = () =>
     (process.env.NAIS_CLUSTER_NAME as Miljø) === "localhost";
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,7 @@ import { useHentSykefraværsstatistikk } from "../lib/sykefraværsstatistikk-kli
 import { useHentOrgnummer } from "../components/Layout/Banner/Banner";
 import { useHentValgteAktiviteter } from "../lib/forebyggingsplan-klient";
 import { logger } from "../lib/logger";
-import { AltinnKonfig, getAltinnKonfig, isMock } from "../lib/miljø";
+import { AltinnKonfig, getAltinnKonfig, isLabs, isMock } from "../lib/miljø";
 import TestVersjonBanner from "../components/Banner/TestVersjonBanner";
 
 interface Props {
@@ -66,6 +66,14 @@ export const getServerSideProps: GetServerSideProps<Props> = async (
         return {
             redirect: {
                 destination: "/oauth2/login",
+                permanent: false,
+            },
+        };
+    } else if (isLabs()) {
+        return {
+            redirect: {
+                destination:
+                    "https://arbeidsgiver.ekstern.dev.nav.no/forebyggingsplan",
                 permanent: false,
             },
         };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -74,7 +74,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (
             redirect: {
                 destination:
                     "https://arbeidsgiver.ekstern.dev.nav.no/forebyggingsplan",
-                permanent: false,
+                permanent: true,
             },
         };
     }


### PR DESCRIPTION
Redirect skjer i koden.
Mulig alternativ er å lagge en `rewrite-target` fra `labs.nav.no` til `ekstern.dev.nav.no` i en kubernetes ingress. Men denne vil også forsvinne når cluster skrus av. 