### PR TITLE
Metrikker orgnr fix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - progress-bar
+      - metrikker-orgnr-fix
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@navikt/ds-css": "^5.4.1",
                 "@navikt/ds-icons": "3.4.3",
                 "@navikt/ds-react": "^5.4.1",
-                "@navikt/ia-metrikker-client": "1.9.3",
+                "@navikt/ia-metrikker-client": "1.9.4",
                 "@navikt/nav-dekoratoren-moduler": "1.9.0",
                 "@navikt/next-api-proxy": "3.2.0",
                 "@navikt/tokenx-middleware": "1.2.4",
@@ -3379,9 +3379,9 @@
             }
         },
         "node_modules/@navikt/ia-metrikker-client": {
-            "version": "1.9.3",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/ia-metrikker-client/1.9.3/4a0223ac8d758e844f446254617c9a8069af4b17",
-            "integrity": "sha512-WC4+LpNqQH+7CwcURD/IUOhV9+38kVKxcXF9hDML/wfTyI/0Wiwj/4jZXWgKyCLtatrcUbSMzDJVZIAyjjI7Ig==",
+            "version": "1.9.4",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/ia-metrikker-client/1.9.4/5587c35968c01ad7449321b7574d07f94f6e79d7",
+            "integrity": "sha512-Iem79wQa+XTxAN3lfuyBkfe/nTq6VKGHzNlknPJNmv6Vff/FSiBTRy5o+fdV80i4BLJUALD0dJauLWnwpRt3DA==",
             "license": "MIT"
         },
         "node_modules/@navikt/nav-dekoratoren-moduler": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "@navikt/ds-icons": "3.4.3",
         "@navikt/ds-react": "^5.4.1",
         "@navikt/aksel-icons": "^5.4.1",
-        "@navikt/ia-metrikker-client": "1.9.3",
+        "@navikt/ia-metrikker-client": "1.9.4",
         "@navikt/nav-dekoratoren-moduler": "1.9.0",
         "@navikt/next-api-proxy": "3.2.0",
         "@navikt/tokenx-middleware": "1.2.4",

--- a/src/lib/klient/ia-metrikker-klient.ts
+++ b/src/lib/klient/ia-metrikker-klient.ts
@@ -16,7 +16,12 @@ export const lagreIaMetrikkInteraksjonstjeneste = (orgnr: string | null) => {
 };
 
 const sendIaMetrikkEvent = (orgnr: string | null, type: MetrikkType) => {
-    if (!orgnr) return;
+    if (!orgnr) {
+        logger.warn(
+            `Orgnr er null, kan ikke sende IA-metrikker av type: ${type}`,
+        );
+        return;
+    }
 
     return sendIaMetrikk(
         orgnr,

--- a/src/lib/klient/ia-metrikker-klient.ts
+++ b/src/lib/klient/ia-metrikker-klient.ts
@@ -4,6 +4,7 @@ import {
     MetrikkKilde,
 } from "@navikt/ia-metrikker-client";
 import { logAndThrowException } from "./forebyggingsplan-klient";
+import { logger } from "./logger-klient";
 
 export const IA_METRIKK_PATH = "/forebyggingsplan/api/ia-metrikker";
 

--- a/src/lib/klient/ia-metrikker-klient.ts
+++ b/src/lib/klient/ia-metrikker-klient.ts
@@ -21,10 +21,8 @@ const sendIaMetrikkEvent = (orgnr: string | null, type: MetrikkType) => {
         logger.warn(
             `Orgnr er null, kan ikke sende IA-metrikker av type: ${type}`,
         );
-        console.log("Orgnr er null, kan ikke sende IA-metrikker");
         return;
     }
-    console.log("Orgnr er ikke null. Prøver å sende IA-metrikker");
 
     return sendIaMetrikk(
         orgnr,
@@ -32,7 +30,6 @@ const sendIaMetrikkEvent = (orgnr: string | null, type: MetrikkType) => {
         MetrikkKilde.FOREBYGGINGSPLAN,
         IA_METRIKK_PATH,
     ).catch((res) => {
-        console.warn("Kunne ikke sende IA-metrikker", res);
         logAndThrowException(res, IA_METRIKK_PATH, "POST");
     });
 };

--- a/src/lib/klient/ia-metrikker-klient.ts
+++ b/src/lib/klient/ia-metrikker-klient.ts
@@ -21,13 +21,18 @@ const sendIaMetrikkEvent = (orgnr: string | null, type: MetrikkType) => {
         logger.warn(
             `Orgnr er null, kan ikke sende IA-metrikker av type: ${type}`,
         );
+        console.log("Orgnr er null, kan ikke sende IA-metrikker");
         return;
     }
+    console.log("Orgnr er ikke null. Prøver å sende IA-metrikker");
 
     return sendIaMetrikk(
         orgnr,
         type,
         MetrikkKilde.FOREBYGGINGSPLAN,
         IA_METRIKK_PATH,
-    ).catch((res) => logAndThrowException(res, IA_METRIKK_PATH, "POST"));
+    ).catch((res) => {
+        console.warn("Kunne ikke sende IA-metrikker", res);
+        logAndThrowException(res, IA_METRIKK_PATH, "POST");
+    });
 };


### PR DESCRIPTION
Oppgraderte til nye versjonen av ia-metrikker-client, som fikset at det bare ble sendt en metrikk per session, selv om det var forskjellige typer.
Satte opp en warning dersom orgnr ikke blir sendt til metrikkene, for å unngå silent failing.